### PR TITLE
Change button bindings for chamber/intake

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -147,13 +147,16 @@ public class RobotContainer {
     new JoystickButton(m_operatorController, OIConstants.kIntakeOn)
       .debounce(OIConstants.kDebounceSeconds)
       .onTrue(Commands.runOnce(
-        () -> m_intake.startIntake()
+        () -> m_chamber.chamberNote()
       ));
 
     new JoystickButton(m_operatorController, OIConstants.kIntakeOff)
       .debounce(OIConstants.kDebounceSeconds)
       .onTrue(Commands.runOnce(
-        () -> m_intake.stopIntake()
+        () -> {
+          m_chamber.cancelChambering();
+          m_intake.stopIntake();
+        }
       ));
 
     new JoystickButton(m_operatorController, OIConstants.kIntakeReverse)


### PR DESCRIPTION
Use chamberNote() rather than startIntake() so that both the intake and the chamber run.

Use cancelChambering() in addition to stopIntake() to stop both the intake and the chamber. This is brittle; in the longer term we should make it possible to reverse the intake without messing up the chamber logic.