### PR TITLE
Move camera2 to a forward-facing position

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -286,11 +286,11 @@ public final class Constants {
     public static final String kCameraName1 = "camera1";
     public static final String kCameraName2 = "camera2";
     public static final Transform3d kRobotToCamera1Transform = new Transform3d(
-      0.196, 0.238, 0.26,
+      0.196, -0.238, 0.26,
       new Rotation3d(0.0, Units.degreesToRadians(-21.0), 0.0));
     public static final Transform3d kRobotToCamera2Transform = new Transform3d(
-      0.126, -0.306, 0.297,
-      new Rotation3d(Units.degreesToRadians(-20.5), 0.0, Units.degreesToRadians(90.0)));
+      0.196, 0.238, 0.26,
+      new Rotation3d(0.0, Units.degreesToRadians(-20.5), 0.0));
   }
 
   public static final class IntakeConstants {


### PR DESCRIPTION
camera1 and camera2 are positioned symmetrically, but their pitches differ slightly due to mounting bracket variance.