### PR TITLE
Stop chamber when reversing intake

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -187,7 +187,10 @@ public class RobotContainer {
     new JoystickButton(m_operatorController, OIConstants.kIntakeReverse)
       .debounce(OIConstants.kDebounceSeconds)
       .onTrue(Commands.runOnce(
-        () -> m_intake.reverseIntake()
+        () -> {
+          m_chamber.cancelChambering();
+          m_intake.reverseIntake();
+        }
       ));
 
     new JoystickButton(m_operatorController, OIConstants.kEjectButton)


### PR DESCRIPTION
The point of reversing the intake is to spit a note back out. Leaving the chamber running is pointless, possibly harmful.