### PR TITLE
Adding pickup commands to the two notes

### DIFF
--- a/src/main/deploy/pathplanner/autos/two note A auto.auto
+++ b/src/main/deploy/pathplanner/autos/two note A auto.auto
@@ -36,6 +36,12 @@
           }
         },
         {
+          "type": "named",
+          "data": {
+            "name": "PickupCommand"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "return to A shooting pos"

--- a/src/main/deploy/pathplanner/autos/two note B auto.auto
+++ b/src/main/deploy/pathplanner/autos/two note B auto.auto
@@ -30,6 +30,12 @@
           }
         },
         {
+          "type": "named",
+          "data": {
+            "name": "PickupCommand"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "rotate around the B note"

--- a/src/main/deploy/pathplanner/autos/two note H auto.auto
+++ b/src/main/deploy/pathplanner/autos/two note H auto.auto
@@ -30,6 +30,12 @@
           }
         },
         {
+          "type": "named",
+          "data": {
+            "name": "PickupCommand"
+          }
+        },
+        {
           "type": "path",
           "data": {
             "pathName": "shoot H note"


### PR DESCRIPTION
All of the autos that pickup notes are missing `PickupCommand`. I added it to just the two notes. 