### PR TITLE
Left and Right Cross The Line

### DIFF
--- a/src/main/deploy/pathplanner/autos/Cross The Line Left.auto
+++ b/src/main/deploy/pathplanner/autos/Cross The Line Left.auto
@@ -1,0 +1,19 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "path",
+          "data": {
+            "pathName": "Left Start Cross The Line"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/autos/Cross The Line Right.auto
+++ b/src/main/deploy/pathplanner/autos/Cross The Line Right.auto
@@ -1,0 +1,19 @@
+{
+  "version": "2025.0",
+  "command": {
+    "type": "sequential",
+    "data": {
+      "commands": [
+        {
+          "type": "path",
+          "data": {
+            "pathName": "Right Start Cross The Line"
+          }
+        }
+      ]
+    }
+  },
+  "resetOdom": true,
+  "folder": null,
+  "choreoAuto": false
+}

--- a/src/main/deploy/pathplanner/paths/Left Start Cross The Line.path
+++ b/src/main/deploy/pathplanner/paths/Left Start Cross The Line.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 7.168861607142857,
+        "y": 6.158647260273973
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.918861607142857,
+        "y": 6.158647260273973
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 6.881763698630137,
+        "y": 6.158647260273973
+      },
+      "prevControl": {
+        "x": 7.131763698630137,
+        "y": 6.158647260273973
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "reversed": false,
+  "folder": null,
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/deploy/pathplanner/paths/Right Start Cross The Line.path
+++ b/src/main/deploy/pathplanner/paths/Right Start Cross The Line.path
@@ -1,0 +1,54 @@
+{
+  "version": "2025.0",
+  "waypoints": [
+    {
+      "anchor": {
+        "x": 7.1296875,
+        "y": 1.8704241071428567
+      },
+      "prevControl": null,
+      "nextControl": {
+        "x": 6.8796875,
+        "y": 1.8704241071428567
+      },
+      "isLocked": false,
+      "linkedName": null
+    },
+    {
+      "anchor": {
+        "x": 6.842410714285713,
+        "y": 1.8704241071428567
+      },
+      "prevControl": {
+        "x": 7.092410714285713,
+        "y": 1.8704241071428567
+      },
+      "nextControl": null,
+      "isLocked": false,
+      "linkedName": null
+    }
+  ],
+  "rotationTargets": [],
+  "constraintZones": [],
+  "pointTowardsZones": [],
+  "eventMarkers": [],
+  "globalConstraints": {
+    "maxVelocity": 3.0,
+    "maxAcceleration": 3.0,
+    "maxAngularVelocity": 540.0,
+    "maxAngularAcceleration": 720.0,
+    "nominalVoltage": 12.0,
+    "unlimited": false
+  },
+  "goalEndState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "reversed": false,
+  "folder": null,
+  "idealStartingState": {
+    "velocity": 0,
+    "rotation": 180.0
+  },
+  "useDefaultConstraints": true
+}

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -88,7 +88,11 @@ public class RobotContainer {
       );
 
       m_chooser.setDefaultOption("Empty Auto", new PathPlannerAuto("Empty Auto"));
-      m_chooser.addOption("Some Auto", new PathPlannerAuto("Some Auto"));
+      m_chooser.addOption("Cross The Line Middle", new PathPlannerAuto("Cross The Line Middle"));
+      m_chooser.addOption("Cross The Line Left", new PathPlannerAuto("Cross The Line Left"));
+      m_chooser.addOption("Cross The Line Right", new PathPlannerAuto("Cross The Line Right"));
+
+
       SmartDashboard.putData(m_chooser);
   }
 


### PR DESCRIPTION
Simple Autos that cross the start line on the left and right positions. Should be committed AFTER Cross The Middle, or else they won't work properly (they require the pathplanner update included in Cross The Middle)